### PR TITLE
Fix Ethernet privileges

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1919,7 +1919,9 @@ inline void requestEthernetInterfacesRoutes(App& app)
             });
 
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/")
-        .privileges(redfish::privileges::patchEthernetInterface)
+        .privileges(
+            redfish::privileges::
+                patchEthernetInterfaceSubOverManagerEthernetInterfaceCollection)
 
         .methods(boost::beast::http::verb::patch)(
             [](const crow::Request& req,
@@ -2113,9 +2115,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/<str>/")
-        // This privilege is incorrect, it should be ConfigureManager
-        //.privileges(redfish::privileges::patchVLanNetworkInterface)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::patchVLanNetworkInterface)
         .methods(boost::beast::http::verb::patch)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2195,9 +2195,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
     BMCWEB_ROUTE(
         app, "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/<str>/")
-        // This privilege is incorrect, it should be ConfigureManager
-        //.privileges(redfish::privileges::deleteVLanNetworkInterface)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::deleteVLanNetworkInterface)
         .methods(boost::beast::http::verb::delete_)(
             [](const crow::Request& /* req */,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2308,9 +2306,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/")
-        // This privilege is wrong, it should be ConfigureManager
-        //.privileges(redfish::privileges::postVLanNetworkInterfaceCollection)
-        .privileges({{"ConfigureComponents"}})
+        .privileges(redfish::privileges::postVLanNetworkInterfaceCollection)
         .methods(boost::beast::http::verb::post)(
             [](const crow::Request& req,
                const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,


### PR DESCRIPTION
Post method:
  1) /redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/
     ConfigureComponents -> ConfigureManager

Patch method:
  1) /redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/<str>/
     ConfigureComponents -> ConfigureManager

  2) /redfish/v1/Managers/bmc/EthernetInterfaces/<str>/
     ConfigureComponents -> ConfigureManager (SubordinateOverrides)

Delete method:
  1) /redfish/v1/Managers/bmc/EthernetInterfaces/<str>/VLANs/<str>/
     ConfigureComponents -> ConfigureManager

This change allows only Admin user to post, patch, and delete on VLAN
Network Interface Collection and restrict Operator user.
Same for the EthernetInterfaces patch method.

Tested: Ran curl test with admin and operator privileged user for
        all methods (post, patch, and delete). one test failing.

Error: curl -k -H "X-Auth-Token: $bmc_token"  -X PATCH -d
       '{"VLANId" :30 , "VLANEnable" : true}'
       https://${BMC_IP}/redfish/v1/Managers/bmc/EthernetInterfaces/
       eth0/VLANs/eth0_50

       This command is unable to update the VLANId value. instead, it
       deletes VLAN

Email sent to openbmc list:
https://lists.ozlabs.org/pipermail/openbmc/2021-August/027232.html

Signed-off-by: Abhishek Patel <Abhishek.Patel@ibm.com>
Change-Id: I4101c429db6fa788909982b66445b191ccacaec7